### PR TITLE
Update build-unix.md

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -59,7 +59,7 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-	sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libevent-dev
+	sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libevent-dev automake
 
 For Ubuntu 12.04 and later or Debian 7 and later libboost-all-dev has to be installed:
 


### PR DESCRIPTION
I noticed aclocal/automake was missing on the list of build dependencies.

Also, running just `./configure` will error on a clean system due to `hexdump` missing. I'd either suggest directly suggesting to run `./configure --disable-tests` or add the dependency accordingly.